### PR TITLE
[INF] add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.4.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-added-large-files
+- repo: https://github.com/psf/black
+  rev: stable
+  hooks:
+  - id: black
+    language_version: python3.7
+- repo: https://github.com/pycqa/isort
+  rev: 5.5.3
+  hooks:
+  - id: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.black]
+line-length = 88
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | env
+  | venv
+)/
+'''
+
+[tool.isort]
+multi_line_output=3
+import_heading_stdlib='Standard libraries'
+import_heading_thirdparty='Third-party libraries'
+import_heading_firstparty='Local libraries'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ XlsxWriter
 codecov
 pytest
 pytest-cov
-
+pre-commit


### PR DESCRIPTION
- Adds `pre-commit` hooks to repo
- Hooks added:
  - `trailing_whitespace`
  - `end-of-file-fixer`
  - `check-yaml`
  - `check-added-large-files`
  - `black`
  - `isort`

**Note**: `interrogate` and `darglint` intentionally left out. Can explore adding these in the future.