### PR TITLE
[INF] Fix badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
 language: python
 
 # command to install dependencies
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
 install:
   - pip install -r requirements.txt
 
 # command to run tests (report "this directory" i.e. "dot")
 script:
-    - pytest --cov-report term-missing --cov=.
+  - pytest --cov-report term-missing --cov=.  --color=yes
 
 env:
- - CODECOV_TOKEN=$CODECOV_TOKEN
+  - CODECOV_TOKEN=$CODECOV_TOKEN
+  - CC_TEST_REPORTER_ID=$CC_TEST_REPORTER_ID
 
 after_success:
- - codecov
+  - codecov
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Build Status](https://img.shields.io/travis/loganthomas/turkey-bowl/master.svg?logo=travis)](https://travis-ci.com/loganthomas/turkey-bowl)
 [![codecov](https://codecov.io/gh/loganthomas/turkey-bowl/branch/master/graph/badge.svg)](https://codecov.io/gh/loganthomas/turkey-bowl)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/3d9b862d5a414e64b3ffe804b9a73eee)](https://www.codacy.com/manual/loganthomas/turkey-bowl/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=loganthomas/turkey-bowl&amp;utm_campaign=Badge_Grade)
+[![Maintainability](https://api.codeclimate.com/v1/badges/08d1578979aeb217b85a/maintainability)](https://codeclimate.com/github/loganthomas/turkey-bowl/maintainability)
+
 
 This repo contains Turkey Bowl fantasy football draft and scoring code.
 


### PR DESCRIPTION
# Infrastructure Updates
- Added `codeclimate` dependencies to `.travis.yml`

# Documentation Updates
- Added `codeclimate` __maintainabiility__ badge to `README.md`
  - The test coverage badge for codeclimate is left off as the code coverage is already reported by `codecov`.
  - A test coverage report is still sent to `codeclimate` and can be viewed there separately.

- Closes #22 
- Closes #24 
- Closes #30 