### PR TITLE
Bumpversion setup into Development

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 2020.01
-commit = False
+commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)
 serialize = {major}.{minor}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,9 @@
+[bumpversion]
+current_version = 2020.01
+commit = False
+tag = False
+parse = (?P<major>\d+)\.(?P<minor>\d+)
+serialize = {major}.{minor}
+
+[bumpversion:file:setup.py]
+[bumpversion:file:src/turkey_bowl/__init__.py]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black
+bump2version
 click-spinner
 check-manifest
 codecov

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     extra_require={
         "dev": [
             "black>=20.8b1",
+            "bump2version>=1.0.1",
             "check-manifest>=0.45",
             "codecov>=2.1.10",
             "pre-commit>=2.8.2",

--- a/src/turkey_bowl/__init__.py
+++ b/src/turkey_bowl/__init__.py
@@ -5,3 +5,5 @@ from turkey_bowl import leader_board  # noqa: F401
 from turkey_bowl import scrape  # noqa: F401
 from turkey_bowl import turkey_bowl_runner  # noqa: F401
 from turkey_bowl import utils  # noqa: F401
+
+__version__ = "2020.01"


### PR DESCRIPTION
`bump2version` can now be used to update versions automatically
- The tagging/versioning is a non-standard python versioning to help me remember what year in which things were released/updated (`year.incremental_release` is really `major.minor`)
- Example usage:

```bash
# To update the year (major) release... results in 2021.0
$ bump2version --current-version 2020.01 major`
```

```bash
# To update the incremental_release (minor) release... results in 2020.2
$ bump2version --current-version 2020.01 minor`
```

__Note__: I should have not had a `0` prefix, will be updated in all new released versions (i.e. `bump2version` doesn't use `2020.02` but rather `2020.2`. This is expected and should be followed from here on...).

Closes #34 