### PR TITLE
ENH: add ability to report `turkey-bowl` version at the command line

### DIFF
--- a/src/turkey_bowl/cli.py
+++ b/src/turkey_bowl/cli.py
@@ -1,17 +1,18 @@
 import logging
 import shutil
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 import typer
 
-from turkey_bowl import aggregate, utils
+from turkey_bowl import __version__, aggregate, utils
 from turkey_bowl.draft import Draft
 from turkey_bowl.leader_board import LeaderBoard
 from turkey_bowl.scrape import Scraper
 
 # Main CLI entry point
-app = typer.Typer()
+app = typer.Typer(help="Turkey Bowl fantasy football draft CLI")
 
 # Set option for nice DataFrame display
 pd.options.display.width = None
@@ -44,7 +45,9 @@ def clean():
 def setup():
     """Setup output directory and create draft order."""
     utils.setup_logger()
-    logger.info(HEADER.format(message=f" {YEAR} Turkey Bowl "))
+    logger.info(
+        HEADER.format(message=f" {YEAR} Turkey Bowl ") + f"turkey-bowl version: {__version__}\n"
+    )
     draft = Draft(YEAR)
     draft.setup()
 
@@ -147,6 +150,29 @@ def scrape_actual(
     board = LeaderBoard(YEAR, participant_teams)
     board.display()
     board.save(Path(f"{draft.dir_config.output_dir}/{YEAR}_leader_board.xlsx"))
+
+
+def version_callback(value: bool):
+    """
+    Report current version of turkey-bowl package.
+    """
+    if value:
+        typer.echo(f"{__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        "-V",
+        callback=version_callback,
+        is_eager=True,
+        help="Report current version of turkey-bowl package.",
+    )
+):
+    return
 
 
 if __name__ == "__main__":

--- a/src/turkey_bowl/draft.py
+++ b/src/turkey_bowl/draft.py
@@ -34,9 +34,9 @@ class Draft:
             self.dir_config.output_dir.mkdir()
 
         if not self.dir_config.draft_order_path.exists():
-            participant_list = input(
-                "\nPlease enter the participants separated by a comma: "
-            ).split(",")
+            participant_list = input("Please enter the participants separated by a comma: ").split(
+                ","
+            )
 
             self.participant_list = [*map(str.strip, participant_list)]
 

--- a/src/turkey_bowl/draft.py
+++ b/src/turkey_bowl/draft.py
@@ -34,9 +34,7 @@ class Draft:
             self.dir_config.output_dir.mkdir()
 
         if not self.dir_config.draft_order_path.exists():
-            participant_list = input("Please enter the participants separated by a comma: ").split(
-                ","
-            )
+            participant_list = input("Please enter participants separated by a comma: ").split(",")
 
             self.participant_list = [*map(str.strip, participant_list)]
 


### PR DESCRIPTION
Add new feature for `turkey-bowl --version` and `turkey-bowl -V` (note that `-v` is reserved for verbosity). Also add version reporting to logs when using `turkey-bowl setup`.

- See `typer` tutorial [Version CLI Option](https://typer.tiangolo.com/tutorial/options/version/) and issue for porting tutorial when using `app = typer.Typer()`: https://github.com/tiangolo/typer/issues/52
